### PR TITLE
fix: resolve javascript syntax error in editor

### DIFF
--- a/admin/editor.html
+++ b/admin/editor.html
@@ -1535,8 +1535,7 @@
                 if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
                 const data = await res.json();
-                const decoded = decodeURIComponent(escape(atob(data.content.replace(/
-/g, ''))));
+                const decoded = decodeURIComponent(escape(atob(data.content.replace(/\\n/g, ''))));
                 
                 // Safe JSON parsing
                 const items = JSON.parse(decoded);


### PR DESCRIPTION
原因を調査したところ、admin/editor.html 内のJavaScriptにおいて、正規表現（改行コードの置換）の記述に構文エラー（Syntax Error）が発生しており、そのエラーによってブラウザ上でスクリプトが途中で停止してしまっていたため、ボタンが反応しない状態になっていました。